### PR TITLE
Add Redis Sentinel support via Jedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ExperimentsInJava
+
+This project contains a simple Spring Boot application used for various experiments. 
+
+## Redis Sentinel with Jedis
+
+The application is configured to connect to Redis via Sentinel using the Jedis client. Configuration properties can be adjusted in `src/main/resources/application.yml`.

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
         </dependency>

--- a/src/main/java/com/experiments/experimentsinjavatemplate/RedisConfig.java
+++ b/src/main/java/com/experiments/experimentsinjavatemplate/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.experiments.experimentsinjavatemplate;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.sentinel.master}")
+    private String master;
+
+    @Value("${spring.data.redis.sentinel.nodes}")
+    private String nodes;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        Set<String> sentinels = Stream.of(nodes.split(","))
+                .collect(Collectors.toSet());
+        RedisSentinelConfiguration config = new RedisSentinelConfiguration(master, sentinels);
+        if (!password.isBlank()) {
+            config.setPassword(RedisPassword.of(password));
+        }
+        return new JedisConnectionFactory(config);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ExperimentsInJavaTemplate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: ExperimentsInJavaTemplate
+  data:
+    redis:
+      client-type: jedis
+      sentinel:
+        master: mymaster
+        nodes:
+          - localhost:26379
+          - localhost:26380
+      # password: yourpassword
+      # database: 0


### PR DESCRIPTION
## Summary
- switch to `application.yml` and add Redis sentinel configuration
- add a `RedisConfig` class that creates a Jedis-based connection factory
- depend on `redis.clients:jedis`
- update README

## Testing
- `./mvnw test -q` *(fails: Permission denied)*
- `mvn test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6f792a888331bff65a2efa32a0e7