### PR TITLE
Add Sentinel auth helper

### DIFF
--- a/src/main/java/com/experiments/experimentsinjavatemplate/RedisConfig.java
+++ b/src/main/java/com/experiments/experimentsinjavatemplate/RedisConfig.java
@@ -5,8 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
-import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import com.experiments.experimentsinjavatemplate.sentinel.SentinelMasterResolver;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,19 +38,19 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         Set<String> sentinels = Stream.of(nodes.split(","))
                 .collect(Collectors.toSet());
-        RedisSentinelConfiguration config = new RedisSentinelConfiguration(master, sentinels);
+
+        // Resolve master address with authentication against Sentinel nodes.
+        SentinelMasterResolver resolver = new SentinelMasterResolver(master, sentinels, sentinelUsername, sentinelPassword);
+        var masterAddr = resolver.resolve();
+
+        RedisStandaloneConfiguration standalone = new RedisStandaloneConfiguration(masterAddr.getHost(), masterAddr.getPort());
         if (!password.isBlank()) {
-            config.setPassword(RedisPassword.of(password));
+            standalone.setPassword(RedisPassword.of(password));
         }
         if (!username.isBlank()) {
-            config.setUsername(username);
+            standalone.setUsername(username);
         }
-        if (!sentinelUsername.isBlank()) {
-            config.setSentinelUsername(sentinelUsername);
-        }
-        if (!sentinelPassword.isBlank()) {
-            config.setSentinelPassword(RedisPassword.of(sentinelPassword));
-        }
-        return new JedisConnectionFactory(config);
+
+        return new JedisConnectionFactory(standalone);
     }
 }

--- a/src/main/java/com/experiments/experimentsinjavatemplate/sentinel/SentinelMasterResolver.java
+++ b/src/main/java/com/experiments/experimentsinjavatemplate/sentinel/SentinelMasterResolver.java
@@ -1,0 +1,58 @@
+package com.experiments.experimentsinjavatemplate.sentinel;
+
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility to resolve Redis master address from Sentinel with authentication support.
+ */
+public class SentinelMasterResolver {
+
+    private final String masterName;
+    private final Set<String> sentinels;
+    private final String sentinelUsername;
+    private final String sentinelPassword;
+
+    public SentinelMasterResolver(String masterName, Set<String> sentinels, String sentinelUsername, String sentinelPassword) {
+        this.masterName = masterName;
+        this.sentinels = sentinels;
+        this.sentinelUsername = sentinelUsername;
+        this.sentinelPassword = sentinelPassword;
+    }
+
+    public HostAndPort resolve() {
+        for (String sentinel : sentinels) {
+            String[] parts = sentinel.split(":");
+            if (parts.length != 2) {
+                continue;
+            }
+            String host = parts[0];
+            int port;
+            try {
+                port = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException e) {
+                continue;
+            }
+            try (Jedis jedis = new Jedis(host, port)) {
+                if (sentinelPassword != null && !sentinelPassword.isBlank()) {
+                    if (sentinelUsername != null && !sentinelUsername.isBlank()) {
+                        jedis.auth(sentinelUsername, sentinelPassword);
+                    } else {
+                        jedis.auth(sentinelPassword);
+                    }
+                }
+                List<String> addr = jedis.sentinelGetMasterAddrByName(masterName);
+                if (addr != null && addr.size() == 2) {
+                    int masterPort = Integer.parseInt(addr.get(1));
+                    return new HostAndPort(addr.get(0), masterPort);
+                }
+            } catch (Exception e) {
+                // ignore and try next sentinel
+            }
+        }
+        throw new IllegalStateException("Unable to resolve master address from sentinels");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SentinelMasterResolver` to authenticate with Sentinel when resolving the Redis master
- use the resolver in `RedisConfig` to build a Jedis connection from the resolved master

## Testing
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686b8367ab688331b670f827683ad823